### PR TITLE
Allow for interpretation of signed integers

### DIFF
--- a/rtf-interpreter.js
+++ b/rtf-interpreter.js
@@ -155,7 +155,7 @@ class RTFInterpreter extends Writable {
   }
   ctrl$u (num) {
     var charBuf = Buffer.alloc ? Buffer.alloc(2) : new Buffer(2)
-    charBuf.writeUInt16LE(num, 0)
+    charBuf.writeInt16LE(num, 0)
     this.group.addContent(new RTFSpan({value: iconv.decode(charBuf, 'ucs2')}))
   }
   ctrl$super () {


### PR DESCRIPTION
Some RTF documents have signed integers so this change allows for these RTFs to be converted correctly