### PR TITLE
Feature cp932

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The document returned is of the `RTFDocument` class, see below for details.
 
 * The following document code pages:<br>
   437, 737, 775, 850, 852, 853, 855, 857, 858, 860, 861, 863, 865, 866, 869,
-  1125, 1250, 1251, 1252, 1253, 1254, 1257
+  932, 1125, 1250, 1251, 1252, 1253, 1254, 1257
 * Unicode characters.
 * Non-unicode representations of: non-breaking spaces, soft hyphens and non-breaking hyphens.
 * Paragraph alignment: center, justified, left and right

--- a/rtf-interpreter.js
+++ b/rtf-interpreter.js
@@ -71,7 +71,7 @@ class RTFInterpreter extends Writable {
         value: iconv.decode(
           Buffer.from(hexstr, 'hex'), this.group.get('charset'))
       }))
-      this.hexStore.slice(0);
+      this.hexStore.splice(0);
       console.log(hexstr);
     }
   }

--- a/rtf-interpreter.js
+++ b/rtf-interpreter.js
@@ -72,7 +72,6 @@ class RTFInterpreter extends Writable {
           Buffer.from(hexstr, 'hex'), this.group.get('charset'))
       }))
       this.hexStore.splice(0);
-      console.log(hexstr);
     }
   }
 

--- a/rtf-interpreter.js
+++ b/rtf-interpreter.js
@@ -360,7 +360,7 @@ class FontTable extends RTFGroup {
     this.currentFont = {family: 'roman', charset: 'ASCII', name: 'Serif'}
   }
   addContent (text) {
-    this.currentFont.name = text.value.replace(/;\s*$/, '')
+    this.currentFont.name += text.value.replace(/;\s*$/, '')
   }
 }
 
@@ -368,7 +368,7 @@ class Font {
   constructor () {
     this.family = null
     this.charset = null
-    this.name = null
+    this.name = ''
     this.pitch = 0
   }
 }


### PR DESCRIPTION
This is a patch for supporting code page 932 which is used very well in Japan.

This code page uses multibyte characters.
So, the mechanism of ```cmd$hexchar()``` is bit changed in this patch.

This is the sample rtf which uses cp932.
```rtf
{\rtf1\ansi\ansicpg932\cocoartf1561\cocoasubrtf400
{\fonttbl\f0\fnil\fcharset128 HiraKakuProN-W3;}
{\colortbl;\red255\green255\blue255;\red0\green0\blue0;}
{\*\expandedcolortbl;;\cssrgb\c0\c0\c0;}
\paperw11905\paperh16837\margl1133\margr1133\margb1133\margt1133
\deftab720
\pard\pardeftab720\partightenfactor0

\f0\fs22 \cf2 \expnd0\expndtw0\kerning0
\up0 \nosupersub \ulnone \outl0\strokewidth0 \strokec2 \'82\'a0\'82\'a2\'82\'a4\'82\'a6\'82\'a8}
```
