### PR TITLE
fix(interpreter): avoid finish callback after err

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,9 @@ function parse (cb) {
   parser.once('error', errorHandler)
   const interpreter = new RTFInterpreter(document)
   interpreter.on('error', errorHandler)
-  interpreter.on('finish', () => cb(null, document))
+  interpreter.on('finish', () => {
+    if (!errored) cb(null, document)
+  })
   parser.pipe(interpreter)
   return parser
 }


### PR DESCRIPTION
fix(interpreter): avoid finish callback after err

avoid finish callback to be called after error callback has been handled.

Close #17 