### PR TITLE
fix(interpreter): Unsupported charset code #2

### DIFF
--- a/rtf-interpreter.js
+++ b/rtf-interpreter.js
@@ -13,6 +13,7 @@ const availableCP = [
   869, 932, 1125, 1250, 1251, 1252, 1253, 1254, 1257 ]
 const codeToCP = {
   0: 'ASCII',
+  2: 'SYMBOL',
   77: 'MacRoman',
   128: 'SHIFT_JIS',
   129: 'CP949', // Hangul


### PR DESCRIPTION
Add SYMBOL charset to avoid "Unsupported charset code #2" error.

```
{\rtf1\ansi\ansicpg1252\deff0\deflang1036{\fonttbl{\f0\froman\fprq2\fcharset0 Times New Roman;}{\f1\fnil\fcharset0 MS Shell Dlg;}{\f2\fnil\fcharset2 Symbol;}}
```

Reference: https://docs.microsoft.com/en-us/previous-versions/cc194829(v=msdn.10)