### PR TITLE
unicode does indeed use unsigned ints

### DIFF
--- a/rtf-interpreter.js
+++ b/rtf-interpreter.js
@@ -188,7 +188,8 @@ class RTFInterpreter extends Writable {
     var charBuf = Buffer.alloc ? Buffer.alloc(2) : new Buffer(2)
     // RTF, for reasons, represents unicode characters as signed integers
     // thus managing to match literally no one.
-    charBuf.writeInt16LE(num, 0)
+    // Scratch that ^
+    charBuf.writeUInt16LE(num, 0)
     this.group.addContent(new RTFSpan({value: iconv.decode(charBuf, 'ucs2')}))
   }
   ctrl$super () {


### PR DESCRIPTION
I had issues with characters like \u61607 causing value overflow errors. This led me to the assumption that unicode does indeed use unsigned ints. If you found examples telling the opposite I would like you to show them to me :)